### PR TITLE
[Feat] 매칭완료시, 초대코드 화면에서 선물함 뷰로 자동이동

### DIFF
--- a/liveOnReboot/liveOn/Network/Auth/Member/MemberConfigEndPoint.swift
+++ b/liveOnReboot/liveOn/Network/Auth/Member/MemberConfigEndPoint.swift
@@ -14,6 +14,7 @@ enum MemberConfigEndPoint {
     case revokeMember
     case editNickName(param: EditNickNameRequest)
     case editOfficialDate(param: String)
+    case validateCoupleMatching
 }
 
 extension MemberConfigEndPoint: TargetType {
@@ -31,14 +32,14 @@ extension MemberConfigEndPoint: TargetType {
                 return "/api/v1/member/nickname"
             case .editOfficialDate:
                 return "api/v1/member/officialDate"
-            default :
-                return "/api/v1/member"
+            case .validateCoupleMatching:
+                return "/api/v1/member/couple"
         }
     }
     
     var method: Moya.Method {
         switch self {
-            case .fetchMemberProfile:
+            case .fetchMemberProfile, .validateCoupleMatching:
                 return .get
             case .postMemberProfile:
                 return .post
@@ -51,7 +52,7 @@ extension MemberConfigEndPoint: TargetType {
     
     var task: Task {
         switch self {
-            case .fetchMemberProfile, .postMemberProfile, .revokeMember :
+            case .fetchMemberProfile, .postMemberProfile, .revokeMember, .validateCoupleMatching :
                 return .requestPlain
             case .editNickName(let request):
                 return .requestJSONEncodable(request)

--- a/liveOnReboot/liveOn/Network/Auth/Member/MemberConfigService.swift
+++ b/liveOnReboot/liveOn/Network/Auth/Member/MemberConfigService.swift
@@ -107,4 +107,19 @@ class MemberConfigService: ObservableObject {
             }
         }
     }
+    
+    static func validateCoupleMatching(completion: @escaping () -> ())->Bool {
+        var isMatched = false
+        singleton.memberConfigProvider.request(.validateCoupleMatching) { response in
+            switch response {
+                case .success:
+                    isMatched = true
+                    completion()
+                    break
+                case .failure:
+                    isMatched = false
+            }
+        }
+        return isMatched
+    }
 }

--- a/liveOnReboot/liveOn/View/SignIn/InviteCodeView.swift
+++ b/liveOnReboot/liveOn/View/SignIn/InviteCodeView.swift
@@ -16,10 +16,12 @@ struct InviteCodeView: View {
     @State private var showShareSheet = false
     @State var goNext: Bool = false
     @State private var inviteCodeToShow = ""
+    @State private var isMatched = false
     var body: some View {
+        if !isMatched {
         SignInLayoutView(title: SignInLiteral.inviteCodeTitle, description: SignInLiteral.inviteCodeDescription) {
             VStack {
-                
+                NavigationLink("", destination: GiftBoxView(), isActive: $isMatched)
                 //TODO: 코드 GET API 연동
                 Text( UserDefaults.standard.string(forKey: "inviteCode") ?? "")
                     .font(.title)
@@ -54,6 +56,7 @@ struct InviteCodeView: View {
             .fullScreenCover(isPresented: $showEnterCodeSheet) {
                 EnterCodeView(userData: userData)
             }
+                
             }
             .frame(maxWidth: .infinity)
 //            .toolbar {
@@ -68,7 +71,15 @@ struct InviteCodeView: View {
             if UserDefaults.standard.string(forKey: "inviteCode") == nil {
                 await MemberConfigService.getInviteCode()
             }
+             MemberConfigService.validateCoupleMatching {
+                self.isMatched = true
+                UserStatus.updateUserStatus(status: UserStatus.allSettingFinished)
+            }
         }
+        } else {
+            GiftBoxView()
+        }
+        
     }
     
     var copyButton: some View {

--- a/liveOnReboot/liveOn/liveOnRebootApp.swift
+++ b/liveOnReboot/liveOn/liveOnRebootApp.swift
@@ -31,7 +31,7 @@ struct liveOnRebootApp: App {
                                       default :
                                           GettingStartView()
                                   }
-                    GiftBoxView()
+
                 }
             } else {
                 Text("네트워크에 연결되지 않았어요 ㅠ")


### PR DESCRIPTION
## 🟣 관련 이슈
#46 

## 🟣 구현/변경 사항 및 이유
기존 매칭이 되어도 초대코드 보낸 사람은 초대코드 화면에서 머물렀는데요,
서버에서 매칭됐는지 검증여부를 보내주는 api 활용해 매칭됐다면 선물함뷰로 넘어가도록 했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
