### PR TITLE
[Feat] 사진 선물리스트 뷰 우측 상단 사진 선물 버튼 추가

### DIFF
--- a/liveOnReboot/liveOn/View/Gift/Picture/PictureListView.swift
+++ b/liveOnReboot/liveOn/View/Gift/Picture/PictureListView.swift
@@ -41,7 +41,18 @@ struct PictureListView: View {
                             isLoaded.toggle()
                         }
                     }
-                } // ScrollView
+                }
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        NavigationLink(destination: SendPictureView(gotoMain: .constant(false))) {
+                            Image("addButton")
+                                .resizable()
+                                .frame(width: 24, height: 24, alignment: .center)
+                                .aspectRatio(contentMode: .fit)
+                        }
+                    }
+                }
+                // ScrollView
                 .blur(radius: isTapped ? 6 : 0)
                 .background(Color.lightgray)
             } else if viewModel.loadedImageList.isEmpty {


### PR DESCRIPTION
## 🟣 관련 이슈
#80 

## 🟣 구현/변경 사항 및 이유
다른 선물 리스트 뷰와 통일하기 위해 사진 선물함 뷰의 우측 상단에도 사진 선물을 바로 할 수 있는 버튼이 추가 되었습니다.

## 결과물
![Simulator Screen Shot - iPhone 13 - 2022-09-09 at 21 14 23](https://user-images.githubusercontent.com/103009135/189347933-a309933c-a3c7-44d8-8053-568169e59414.png)
